### PR TITLE
Close task 18: Edit discovery status from table view.

### DIFF
--- a/EDCodex.Panel/EDCodex.Panel.csproj
+++ b/EDCodex.Panel/EDCodex.Panel.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CSharpDLLPanelEDDClass.cs" />
+    <Compile Include="Extentions\CodexEntryExtensions.cs" />
     <Compile Include="FilterType.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Models\CodexEntryView.cs" />

--- a/EDCodex.Panel/Extentions/CodexEntryExtensions.cs
+++ b/EDCodex.Panel/Extentions/CodexEntryExtensions.cs
@@ -1,0 +1,25 @@
+﻿using EDCodex.Data.Enums;
+using EDCodex.Data.Models;
+
+namespace EDCodex.Panel.Extentions
+{
+    public static class CodexEntryExtensions
+    {
+        /// <summary>
+        /// Returns the status of the codex entry for the current galactic region.
+        /// If no status is found, returns <see cref="CodexEntryStatus.Undefined"/>.
+        /// </summary>
+        /// <param name="entry">The codex entry to retrieve the status for.</param>
+        public static CodexEntryStatus GetStatusForRegion(this ICodexEntry entry, GalacticRegion region)
+        {
+            if (entry == null)
+            {
+                throw new System.ArgumentNullException(nameof(entry));
+            }
+
+            return entry.StatusByGalacticRegion.TryGetValue(region, out var status)
+                ? status
+                : CodexEntryStatus.Undefined;
+        }
+    }
+}

--- a/EDCodex.Panel/Models/CodexEntryView.cs
+++ b/EDCodex.Panel/Models/CodexEntryView.cs
@@ -1,11 +1,34 @@
-﻿using EDCodex.Data.Enums;
+﻿using EDCodex.Data;
+using EDCodex.Data.Enums;
+using EDCodex.Data.Models;
+using EDCodex.Panel.Extentions;
 
 namespace EDCodex.Panel.Models
 {
     public class CodexEntryView
     {
-        public string Description { get; set; }
+        private ICodexEntry _codexEntry;
+        private readonly Codex _codex;
 
-        public CodexEntryStatus Status { get; set; }
+        public CodexEntryView(ICodexEntry codexEntry, Codex codex)
+        {
+            _codexEntry = codexEntry ?? throw new System.ArgumentNullException(nameof(codexEntry));
+            _codex = codex ?? throw new System.ArgumentNullException(nameof(codex));
+        }
+
+        public string Description
+        {
+            get => _codexEntry.Description;
+        }
+
+        public CodexEntryStatus Status
+        {
+            get => _codexEntry.GetStatusForRegion(_codex.CurrentRegion);
+            set
+            {
+                _codexEntry.StatusByGalacticRegion[_codex.CurrentRegion] = value;
+                DbAccessor.SaveCodex(); // TODO: Ask is it SRP violation?..
+            }
+        }
     }
 }

--- a/EDCodex.Panel/Models/CodexEntryView.cs
+++ b/EDCodex.Panel/Models/CodexEntryView.cs
@@ -1,5 +1,4 @@
-﻿using EDCodex.Data;
-using EDCodex.Data.Enums;
+﻿using EDCodex.Data.Enums;
 using EDCodex.Data.Models;
 using EDCodex.Panel.Extentions;
 
@@ -27,7 +26,6 @@ namespace EDCodex.Panel.Models
             set
             {
                 _codexEntry.StatusByGalacticRegion[_codex.CurrentRegion] = value;
-                DbAccessor.SaveCodex(); // TODO: Ask is it SRP violation?..
             }
         }
     }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -399,11 +399,7 @@ namespace EDCodex.Panel
                     continue;
                 }
 
-                _filteredEntries.Add(new CodexEntryView
-                {
-                    Description = entry.Description,
-                    Status = status,
-                });
+                _filteredEntries.Add(new CodexEntryView(entry, Codex));
             }
 
             _logger.Debug($"{_filteredEntries.Count} {_selectedDiscoveryType} entries loaded for {_selectedRegion} region."); // [+msg]

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -1,6 +1,7 @@
 ﻿using EDCodex.Data;
 using EDCodex.Data.Enums;
 using EDCodex.Data.Models;
+using EDCodex.Panel.Extentions;
 using EDCodex.Panel.Models;
 using System;
 using System.Collections.Generic;
@@ -391,7 +392,7 @@ namespace EDCodex.Panel
                     continue;
                 }
 
-                var status = GetStatusForCurrentRegion(entry);
+                var status = entry.GetStatusForRegion(Codex.CurrentRegion);
 
                 if (!IsMatchingCurrentFilter(status))
                 {
@@ -426,18 +427,6 @@ namespace EDCodex.Panel
                 default:
                     return false; // Should not reach here.
             }
-        }
-
-        /// <summary>
-        /// Returns the status of the specified codex entry for the current galactic region.
-        /// If no status is found, returns <see cref="CodexEntryStatus.Undefined"/>.
-        /// </summary>
-        /// <param name="entry">The codex entry to retrieve the status for.</param>
-        private CodexEntryStatus GetStatusForCurrentRegion(ICodexEntry entry)
-        {
-            return entry.StatusByGalacticRegion.TryGetValue(Codex.CurrentRegion, out var status)
-                ? status
-                : CodexEntryStatus.Undefined;
         }
     }
 }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -414,22 +414,17 @@ namespace EDCodex.Panel
         /// <returns><c>true</c> if the status matches the current filter; otherwise, <c>false</c>.</returns>
         private bool IsMatchingCurrentFilter(CodexEntryStatus status)
         {
-            if (_currentFilter == FilterType.All)
+            switch (_currentFilter)
             {
-                return true;
+                case FilterType.All:
+                    return true;
+                case FilterType.Existing:
+                    return status == CodexEntryStatus.Exists || status == CodexEntryStatus.Found;
+                case FilterType.NotFound:
+                    return status == CodexEntryStatus.Exists;
+                default:
+                    return false; // Should not reach here.
             }
-
-            if (_currentFilter == FilterType.Existing)
-            {
-                return status == CodexEntryStatus.Exists || status == CodexEntryStatus.Found;
-            }
-
-            if (_currentFilter == FilterType.NotFound)
-            {
-                return status == CodexEntryStatus.Exists;
-            }
-
-            return false; // Should not reach here.
         }
 
         /// <summary>

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -157,6 +157,7 @@ namespace EDCodex.Panel
             dataGridView_codexEntries.AutoGenerateColumns = false;
             dataGridView_codexEntries.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
             dataGridView_codexEntries.AllowUserToAddRows = false;
+            dataGridView_codexEntries.AllowUserToDeleteRows =false;
             dataGridView_codexEntries.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             dataGridView_codexEntries.MultiSelect = false;
         }


### PR DESCRIPTION
Implemented editing discovery status.
Status changes immediately saved to Codex.
Values kept between app launches.