### PR TITLE
System name prefixes functionality implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Ankh.NoLoad
 #Tooling
 _ReSharper*/
 *.resharper
+.idea/
 
 #Project files
 [Bb]uild/

--- a/EDCodex.Panel/CubeService.cs
+++ b/EDCodex.Panel/CubeService.cs
@@ -1,0 +1,35 @@
+﻿using EDCodex.Panel.Enums;
+using System.Collections.Generic;
+
+namespace EDCodex.Panel
+{
+    public static class CubeService
+    {
+        /// <summary>
+        /// Gets a list of cube codes for the specified <see cref="MassIndex"/>.
+        /// </summary>
+        /// <param name="massIndex">The mass index to retrieve cube codes for.</param>
+        /// <returns>
+        /// A list of cube code strings corresponding to the given mass index.
+        /// Returns an empty list if the mass index is not supported.
+        /// </returns>
+        public static List<string> GetForMassIndex(MassIndex massIndex)
+        {
+            switch (massIndex)
+            {
+                case MassIndex.G:
+                    return new List<string>
+                    {
+                        "AA-A", "BA-A", "YE-A", "ZE-A", "EG-Y", "FG-Y", "CL-Y", "DL-Y"
+                    };
+                case MassIndex.H:
+                    return new List<string>
+                    {
+                        "AA-A"
+                    };
+                default:
+                    return new List<string>();
+            }
+        }
+    }
+}

--- a/EDCodex.Panel/EDCodex.Panel.csproj
+++ b/EDCodex.Panel/EDCodex.Panel.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CSharpDLLPanelEDDClass.cs" />
+    <Compile Include="Enums\MassIndex.cs" />
     <Compile Include="Extentions\CodexEntryExtensions.cs" />
     <Compile Include="FilterType.cs" />
     <Compile Include="Logger.cs" />
@@ -58,6 +59,8 @@
     <Compile Include="PanelUserControl.Designer.cs">
       <DependentUpon>PanelUserControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="CubeService.cs" />
+    <Compile Include="PrefixService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/EDCodex.Panel/Enums/MassIndex.cs
+++ b/EDCodex.Panel/Enums/MassIndex.cs
@@ -1,0 +1,14 @@
+﻿namespace EDCodex.Panel.Enums
+{
+    public enum MassIndex
+    {
+        A,
+        B,
+        C,
+        D,
+        E,
+        F,
+        G,
+        H
+    }
+}

--- a/EDCodex.Panel/PanelUserControl.Designer.cs
+++ b/EDCodex.Panel/PanelUserControl.Designer.cs
@@ -32,6 +32,7 @@
             this.comboBox_currentRegion = new System.Windows.Forms.ComboBox();
             this.label_currentRegion = new System.Windows.Forms.Label();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.dataGridView_codexEntries = new System.Windows.Forms.DataGridView();
             this.panel_topControls = new System.Windows.Forms.Panel();
             this.groupBox_discoveryFilters = new System.Windows.Forms.GroupBox();
@@ -40,32 +41,30 @@
             this.radioButton_filterAll = new System.Windows.Forms.RadioButton();
             this.comboBox_discoveryType = new System.Windows.Forms.ComboBox();
             this.label_discoveryType = new System.Windows.Forms.Label();
-            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
-            this.textBox_sectorName = new System.Windows.Forms.TextBox();
-            this.label_sectorName = new System.Windows.Forms.Label();
-            this.button_getPrefixes = new System.Windows.Forms.Button();
             this.listBox_prefixes = new System.Windows.Forms.ListBox();
+            this.button_getPrefixes = new System.Windows.Forms.Button();
+            this.label_sectorName = new System.Windows.Forms.Label();
+            this.textBox_sectorName = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_codexEntries)).BeginInit();
-            this.panel_topControls.SuspendLayout();
-            this.groupBox_discoveryFilters.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
             this.splitContainer2.Panel1.SuspendLayout();
             this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_codexEntries)).BeginInit();
+            this.panel_topControls.SuspendLayout();
+            this.groupBox_discoveryFilters.SuspendLayout();
             this.SuspendLayout();
             // 
             // textBox_logMsgs
             // 
             this.textBox_logMsgs.Dock = System.Windows.Forms.DockStyle.Fill;
             this.textBox_logMsgs.Location = new System.Drawing.Point(0, 0);
-            this.textBox_logMsgs.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_logMsgs.Name = "textBox_logMsgs";
             this.textBox_logMsgs.ReadOnly = true;
-            this.textBox_logMsgs.Size = new System.Drawing.Size(793, 120);
+            this.textBox_logMsgs.Size = new System.Drawing.Size(1190, 186);
             this.textBox_logMsgs.TabIndex = 0;
             this.textBox_logMsgs.Text = "";
             // 
@@ -73,20 +72,18 @@
             // 
             this.comboBox_currentRegion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBox_currentRegion.FormattingEnabled = true;
-            this.comboBox_currentRegion.Location = new System.Drawing.Point(13, 21);
-            this.comboBox_currentRegion.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBox_currentRegion.Location = new System.Drawing.Point(20, 32);
             this.comboBox_currentRegion.Name = "comboBox_currentRegion";
-            this.comboBox_currentRegion.Size = new System.Drawing.Size(183, 21);
+            this.comboBox_currentRegion.Size = new System.Drawing.Size(272, 28);
             this.comboBox_currentRegion.TabIndex = 1;
             this.comboBox_currentRegion.SelectedIndexChanged += new System.EventHandler(this.comboBox_currentRegion_SelectedIndexChanged);
             // 
             // label_currentRegion
             // 
             this.label_currentRegion.AutoSize = true;
-            this.label_currentRegion.Location = new System.Drawing.Point(13, 6);
-            this.label_currentRegion.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label_currentRegion.Location = new System.Drawing.Point(20, 9);
             this.label_currentRegion.Name = "label_currentRegion";
-            this.label_currentRegion.Size = new System.Drawing.Size(73, 13);
+            this.label_currentRegion.Size = new System.Drawing.Size(110, 20);
             this.label_currentRegion.TabIndex = 2;
             this.label_currentRegion.Text = "Current region";
             // 
@@ -94,7 +91,6 @@
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -105,18 +101,43 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.textBox_logMsgs);
-            this.splitContainer1.Size = new System.Drawing.Size(793, 573);
-            this.splitContainer1.SplitterDistance = 450;
-            this.splitContainer1.SplitterWidth = 3;
+            this.splitContainer1.Size = new System.Drawing.Size(1190, 882);
+            this.splitContainer1.SplitterDistance = 691;
+            this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 4;
+            // 
+            // splitContainer2
+            // 
+            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.splitContainer2.Name = "splitContainer2";
+            // 
+            // splitContainer2.Panel1
+            // 
+            this.splitContainer2.Panel1.Controls.Add(this.dataGridView_codexEntries);
+            this.splitContainer2.Panel1.Controls.Add(this.panel_topControls);
+            // 
+            // splitContainer2.Panel2
+            // 
+            this.splitContainer2.Panel2.Controls.Add(this.textBox_sectorName);
+            this.splitContainer2.Panel2.Controls.Add(this.label_sectorName);
+            this.splitContainer2.Panel2.Controls.Add(this.listBox_prefixes);
+            this.splitContainer2.Panel2.Controls.Add(this.button_getPrefixes);
+            this.splitContainer2.Size = new System.Drawing.Size(1190, 691);
+            this.splitContainer2.SplitterDistance = 553;
+            this.splitContainer2.SplitterWidth = 8;
+            this.splitContainer2.TabIndex = 1;
             // 
             // dataGridView_codexEntries
             // 
             this.dataGridView_codexEntries.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView_codexEntries.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dataGridView_codexEntries.Location = new System.Drawing.Point(0, 104);
+            this.dataGridView_codexEntries.Location = new System.Drawing.Point(0, 160);
+            this.dataGridView_codexEntries.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.dataGridView_codexEntries.Name = "dataGridView_codexEntries";
-            this.dataGridView_codexEntries.Size = new System.Drawing.Size(369, 346);
+            this.dataGridView_codexEntries.RowHeadersWidth = 62;
+            this.dataGridView_codexEntries.Size = new System.Drawing.Size(553, 531);
             this.dataGridView_codexEntries.TabIndex = 0;
             // 
             // panel_topControls
@@ -128,9 +149,8 @@
             this.panel_topControls.Controls.Add(this.comboBox_currentRegion);
             this.panel_topControls.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel_topControls.Location = new System.Drawing.Point(0, 0);
-            this.panel_topControls.Margin = new System.Windows.Forms.Padding(2);
             this.panel_topControls.Name = "panel_topControls";
-            this.panel_topControls.Size = new System.Drawing.Size(369, 104);
+            this.panel_topControls.Size = new System.Drawing.Size(553, 160);
             this.panel_topControls.TabIndex = 5;
             // 
             // groupBox_discoveryFilters
@@ -138,9 +158,11 @@
             this.groupBox_discoveryFilters.Controls.Add(this.radioButton_filterNotFound);
             this.groupBox_discoveryFilters.Controls.Add(this.radioButton_filterExisting);
             this.groupBox_discoveryFilters.Controls.Add(this.radioButton_filterAll);
-            this.groupBox_discoveryFilters.Location = new System.Drawing.Point(246, 6);
+            this.groupBox_discoveryFilters.Location = new System.Drawing.Point(369, 9);
+            this.groupBox_discoveryFilters.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox_discoveryFilters.Name = "groupBox_discoveryFilters";
-            this.groupBox_discoveryFilters.Size = new System.Drawing.Size(98, 85);
+            this.groupBox_discoveryFilters.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox_discoveryFilters.Size = new System.Drawing.Size(147, 131);
             this.groupBox_discoveryFilters.TabIndex = 5;
             this.groupBox_discoveryFilters.TabStop = false;
             this.groupBox_discoveryFilters.Text = "Filter by";
@@ -148,9 +170,10 @@
             // radioButton_filterNotFound
             // 
             this.radioButton_filterNotFound.AutoSize = true;
-            this.radioButton_filterNotFound.Location = new System.Drawing.Point(6, 62);
+            this.radioButton_filterNotFound.Location = new System.Drawing.Point(9, 95);
+            this.radioButton_filterNotFound.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radioButton_filterNotFound.Name = "radioButton_filterNotFound";
-            this.radioButton_filterNotFound.Size = new System.Drawing.Size(72, 17);
+            this.radioButton_filterNotFound.Size = new System.Drawing.Size(104, 24);
             this.radioButton_filterNotFound.TabIndex = 2;
             this.radioButton_filterNotFound.TabStop = true;
             this.radioButton_filterNotFound.Text = "Not found";
@@ -159,9 +182,10 @@
             // radioButton_filterExisting
             // 
             this.radioButton_filterExisting.AutoSize = true;
-            this.radioButton_filterExisting.Location = new System.Drawing.Point(6, 39);
+            this.radioButton_filterExisting.Location = new System.Drawing.Point(9, 60);
+            this.radioButton_filterExisting.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radioButton_filterExisting.Name = "radioButton_filterExisting";
-            this.radioButton_filterExisting.Size = new System.Drawing.Size(61, 17);
+            this.radioButton_filterExisting.Size = new System.Drawing.Size(89, 24);
             this.radioButton_filterExisting.TabIndex = 1;
             this.radioButton_filterExisting.TabStop = true;
             this.radioButton_filterExisting.Text = "Existing";
@@ -170,9 +194,10 @@
             // radioButton_filterAll
             // 
             this.radioButton_filterAll.AutoSize = true;
-            this.radioButton_filterAll.Location = new System.Drawing.Point(6, 16);
+            this.radioButton_filterAll.Location = new System.Drawing.Point(9, 25);
+            this.radioButton_filterAll.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radioButton_filterAll.Name = "radioButton_filterAll";
-            this.radioButton_filterAll.Size = new System.Drawing.Size(65, 17);
+            this.radioButton_filterAll.Size = new System.Drawing.Size(93, 24);
             this.radioButton_filterAll.TabIndex = 0;
             this.radioButton_filterAll.TabStop = true;
             this.radioButton_filterAll.Text = "Show all";
@@ -182,106 +207,88 @@
             // 
             this.comboBox_discoveryType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBox_discoveryType.FormattingEnabled = true;
-            this.comboBox_discoveryType.Location = new System.Drawing.Point(13, 70);
-            this.comboBox_discoveryType.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBox_discoveryType.Location = new System.Drawing.Point(20, 108);
             this.comboBox_discoveryType.Name = "comboBox_discoveryType";
-            this.comboBox_discoveryType.Size = new System.Drawing.Size(183, 21);
+            this.comboBox_discoveryType.Size = new System.Drawing.Size(272, 28);
             this.comboBox_discoveryType.TabIndex = 4;
             this.comboBox_discoveryType.SelectedIndexChanged += new System.EventHandler(this.comboBox_discoveryType_SelectedIndexChanged);
             // 
             // label_discoveryType
             // 
             this.label_discoveryType.AutoSize = true;
-            this.label_discoveryType.Location = new System.Drawing.Point(10, 55);
-            this.label_discoveryType.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label_discoveryType.Location = new System.Drawing.Point(15, 85);
             this.label_discoveryType.Name = "label_discoveryType";
-            this.label_discoveryType.Size = new System.Drawing.Size(77, 13);
+            this.label_discoveryType.Size = new System.Drawing.Size(111, 20);
             this.label_discoveryType.TabIndex = 3;
             this.label_discoveryType.Text = "Discovery type";
             // 
-            // splitContainer2
+            // listBox_prefixes
             // 
-            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer2.Name = "splitContainer2";
-            // 
-            // splitContainer2.Panel1
-            // 
-            this.splitContainer2.Panel1.Controls.Add(this.dataGridView_codexEntries);
-            this.splitContainer2.Panel1.Controls.Add(this.panel_topControls);
-            // 
-            // splitContainer2.Panel2
-            // 
-            this.splitContainer2.Panel2.Controls.Add(this.listBox_prefixes);
-            this.splitContainer2.Panel2.Controls.Add(this.button_getPrefixes);
-            this.splitContainer2.Panel2.Controls.Add(this.label_sectorName);
-            this.splitContainer2.Panel2.Controls.Add(this.textBox_sectorName);
-            this.splitContainer2.Size = new System.Drawing.Size(793, 450);
-            this.splitContainer2.SplitterDistance = 369;
-            this.splitContainer2.SplitterWidth = 5;
-            this.splitContainer2.TabIndex = 1;
-            // 
-            // textBox_sectorName
-            // 
-            this.textBox_sectorName.Location = new System.Drawing.Point(6, 22);
-            this.textBox_sectorName.Name = "textBox_sectorName";
-            this.textBox_sectorName.Size = new System.Drawing.Size(115, 20);
-            this.textBox_sectorName.TabIndex = 0;
-            this.textBox_sectorName.TextChanged += new System.EventHandler(this.textBox_sectorName_TextChanged);
-            this.textBox_sectorName.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_sectorName_KeyDown);
-            // 
-            // label_sectorName
-            // 
-            this.label_sectorName.AutoSize = true;
-            this.label_sectorName.Location = new System.Drawing.Point(3, 6);
-            this.label_sectorName.Name = "label_sectorName";
-            this.label_sectorName.Size = new System.Drawing.Size(67, 13);
-            this.label_sectorName.TabIndex = 1;
-            this.label_sectorName.Text = "Sector name";
+            this.listBox_prefixes.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.listBox_prefixes.FormattingEnabled = true;
+            this.listBox_prefixes.ItemHeight = 20;
+            this.listBox_prefixes.Location = new System.Drawing.Point(0, 227);
+            this.listBox_prefixes.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.listBox_prefixes.Name = "listBox_prefixes";
+            this.listBox_prefixes.Size = new System.Drawing.Size(629, 464);
+            this.listBox_prefixes.TabIndex = 3;
+            this.listBox_prefixes.SelectedIndexChanged += new System.EventHandler(this.listBox_prefixes_SelectedIndexChanged);
             // 
             // button_getPrefixes
             // 
             this.button_getPrefixes.Enabled = false;
-            this.button_getPrefixes.Location = new System.Drawing.Point(127, 20);
+            this.button_getPrefixes.Location = new System.Drawing.Point(186, 181);
+            this.button_getPrefixes.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button_getPrefixes.Name = "button_getPrefixes";
-            this.button_getPrefixes.Size = new System.Drawing.Size(152, 23);
+            this.button_getPrefixes.Size = new System.Drawing.Size(228, 35);
             this.button_getPrefixes.TabIndex = 2;
             this.button_getPrefixes.Text = "Get all possible prefixes ";
             this.button_getPrefixes.UseVisualStyleBackColor = true;
             this.button_getPrefixes.Click += new System.EventHandler(this.button_getPrefixes_Click);
             // 
-            // listBox_prefixes
+            // label_sectorName
             // 
-            this.listBox_prefixes.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.listBox_prefixes.FormattingEnabled = true;
-            this.listBox_prefixes.Location = new System.Drawing.Point(0, 56);
-            this.listBox_prefixes.Name = "listBox_prefixes";
-            this.listBox_prefixes.Size = new System.Drawing.Size(419, 394);
-            this.listBox_prefixes.TabIndex = 3;
-            this.listBox_prefixes.SelectedIndexChanged += new System.EventHandler(this.listBox_prefixes_SelectedIndexChanged);
+            this.label_sectorName.AutoSize = true;
+            this.label_sectorName.Location = new System.Drawing.Point(0, 160);
+            this.label_sectorName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_sectorName.Name = "label_sectorName";
+            this.label_sectorName.Size = new System.Drawing.Size(100, 20);
+            this.label_sectorName.TabIndex = 1;
+            this.label_sectorName.Text = "Sector name";
+            // 
+            // textBox_sectorName
+            // 
+            this.textBox_sectorName.Location = new System.Drawing.Point(4, 184);
+            this.textBox_sectorName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.textBox_sectorName.Name = "textBox_sectorName";
+            this.textBox_sectorName.Size = new System.Drawing.Size(170, 26);
+            this.textBox_sectorName.TabIndex = 0;
+            this.textBox_sectorName.TextChanged += new System.EventHandler(this.textBox_sectorName_TextChanged);
+            this.textBox_sectorName.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_sectorName_KeyDown);
             // 
             // PanelUserControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.splitContainer1);
-            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "PanelUserControl";
-            this.Size = new System.Drawing.Size(793, 573);
+            this.Size = new System.Drawing.Size(1190, 882);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_codexEntries)).EndInit();
-            this.panel_topControls.ResumeLayout(false);
-            this.panel_topControls.PerformLayout();
-            this.groupBox_discoveryFilters.ResumeLayout(false);
-            this.groupBox_discoveryFilters.PerformLayout();
             this.splitContainer2.Panel1.ResumeLayout(false);
             this.splitContainer2.Panel2.ResumeLayout(false);
             this.splitContainer2.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
             this.splitContainer2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView_codexEntries)).EndInit();
+            this.panel_topControls.ResumeLayout(false);
+            this.panel_topControls.PerformLayout();
+            this.groupBox_discoveryFilters.ResumeLayout(false);
+            this.groupBox_discoveryFilters.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -301,9 +308,9 @@
         private System.Windows.Forms.RadioButton radioButton_filterExisting;
         private System.Windows.Forms.RadioButton radioButton_filterAll;
         private System.Windows.Forms.SplitContainer splitContainer2;
+        private System.Windows.Forms.ListBox listBox_prefixes;
         private System.Windows.Forms.TextBox textBox_sectorName;
         private System.Windows.Forms.Label label_sectorName;
         private System.Windows.Forms.Button button_getPrefixes;
-        private System.Windows.Forms.ListBox listBox_prefixes;
     }
 }

--- a/EDCodex.Panel/PanelUserControl.Designer.cs
+++ b/EDCodex.Panel/PanelUserControl.Designer.cs
@@ -41,6 +41,10 @@
             this.comboBox_discoveryType = new System.Windows.Forms.ComboBox();
             this.label_discoveryType = new System.Windows.Forms.Label();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
+            this.textBox_sectorName = new System.Windows.Forms.TextBox();
+            this.label_sectorName = new System.Windows.Forms.Label();
+            this.button_getPrefixes = new System.Windows.Forms.Button();
+            this.listBox_prefixes = new System.Windows.Forms.ListBox();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -50,6 +54,7 @@
             this.groupBox_discoveryFilters.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
             this.splitContainer2.Panel1.SuspendLayout();
+            this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -204,10 +209,55 @@
             // 
             this.splitContainer2.Panel1.Controls.Add(this.dataGridView_codexEntries);
             this.splitContainer2.Panel1.Controls.Add(this.panel_topControls);
+            // 
+            // splitContainer2.Panel2
+            // 
+            this.splitContainer2.Panel2.Controls.Add(this.listBox_prefixes);
+            this.splitContainer2.Panel2.Controls.Add(this.button_getPrefixes);
+            this.splitContainer2.Panel2.Controls.Add(this.label_sectorName);
+            this.splitContainer2.Panel2.Controls.Add(this.textBox_sectorName);
             this.splitContainer2.Size = new System.Drawing.Size(793, 450);
             this.splitContainer2.SplitterDistance = 369;
             this.splitContainer2.SplitterWidth = 5;
             this.splitContainer2.TabIndex = 1;
+            // 
+            // textBox_sectorName
+            // 
+            this.textBox_sectorName.Location = new System.Drawing.Point(6, 22);
+            this.textBox_sectorName.Name = "textBox_sectorName";
+            this.textBox_sectorName.Size = new System.Drawing.Size(115, 20);
+            this.textBox_sectorName.TabIndex = 0;
+            this.textBox_sectorName.TextChanged += new System.EventHandler(this.textBox_sectorName_TextChanged);
+            this.textBox_sectorName.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_sectorName_KeyDown);
+            // 
+            // label_sectorName
+            // 
+            this.label_sectorName.AutoSize = true;
+            this.label_sectorName.Location = new System.Drawing.Point(3, 6);
+            this.label_sectorName.Name = "label_sectorName";
+            this.label_sectorName.Size = new System.Drawing.Size(67, 13);
+            this.label_sectorName.TabIndex = 1;
+            this.label_sectorName.Text = "Sector name";
+            // 
+            // button_getPrefixes
+            // 
+            this.button_getPrefixes.Enabled = false;
+            this.button_getPrefixes.Location = new System.Drawing.Point(127, 20);
+            this.button_getPrefixes.Name = "button_getPrefixes";
+            this.button_getPrefixes.Size = new System.Drawing.Size(152, 23);
+            this.button_getPrefixes.TabIndex = 2;
+            this.button_getPrefixes.Text = "Get all possible prefixes ";
+            this.button_getPrefixes.UseVisualStyleBackColor = true;
+            this.button_getPrefixes.Click += new System.EventHandler(this.button_getPrefixes_Click);
+            // 
+            // listBox_prefixes
+            // 
+            this.listBox_prefixes.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.listBox_prefixes.FormattingEnabled = true;
+            this.listBox_prefixes.Location = new System.Drawing.Point(0, 56);
+            this.listBox_prefixes.Name = "listBox_prefixes";
+            this.listBox_prefixes.Size = new System.Drawing.Size(419, 394);
+            this.listBox_prefixes.TabIndex = 3;
             // 
             // PanelUserControl
             // 
@@ -227,6 +277,8 @@
             this.groupBox_discoveryFilters.ResumeLayout(false);
             this.groupBox_discoveryFilters.PerformLayout();
             this.splitContainer2.Panel1.ResumeLayout(false);
+            this.splitContainer2.Panel2.ResumeLayout(false);
+            this.splitContainer2.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
             this.splitContainer2.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -248,5 +300,9 @@
         private System.Windows.Forms.RadioButton radioButton_filterExisting;
         private System.Windows.Forms.RadioButton radioButton_filterAll;
         private System.Windows.Forms.SplitContainer splitContainer2;
+        private System.Windows.Forms.TextBox textBox_sectorName;
+        private System.Windows.Forms.Label label_sectorName;
+        private System.Windows.Forms.Button button_getPrefixes;
+        private System.Windows.Forms.ListBox listBox_prefixes;
     }
 }

--- a/EDCodex.Panel/PanelUserControl.Designer.cs
+++ b/EDCodex.Panel/PanelUserControl.Designer.cs
@@ -34,12 +34,13 @@
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.dataGridView_codexEntries = new System.Windows.Forms.DataGridView();
             this.panel_topControls = new System.Windows.Forms.Panel();
+            this.groupBox_discoveryFilters = new System.Windows.Forms.GroupBox();
+            this.radioButton_filterNotFound = new System.Windows.Forms.RadioButton();
+            this.radioButton_filterExisting = new System.Windows.Forms.RadioButton();
+            this.radioButton_filterAll = new System.Windows.Forms.RadioButton();
             this.comboBox_discoveryType = new System.Windows.Forms.ComboBox();
             this.label_discoveryType = new System.Windows.Forms.Label();
-            this.groupBox_discoveryFilters = new System.Windows.Forms.GroupBox();
-            this.radioButton_filterAll = new System.Windows.Forms.RadioButton();
-            this.radioButton_filterExisting = new System.Windows.Forms.RadioButton();
-            this.radioButton_filterNotFound = new System.Windows.Forms.RadioButton();
+            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -47,6 +48,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView_codexEntries)).BeginInit();
             this.panel_topControls.SuspendLayout();
             this.groupBox_discoveryFilters.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
+            this.splitContainer2.Panel1.SuspendLayout();
+            this.splitContainer2.SuspendLayout();
             this.SuspendLayout();
             // 
             // textBox_logMsgs
@@ -56,7 +60,7 @@
             this.textBox_logMsgs.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_logMsgs.Name = "textBox_logMsgs";
             this.textBox_logMsgs.ReadOnly = true;
-            this.textBox_logMsgs.Size = new System.Drawing.Size(793, 196);
+            this.textBox_logMsgs.Size = new System.Drawing.Size(793, 217);
             this.textBox_logMsgs.TabIndex = 0;
             this.textBox_logMsgs.Text = "";
             // 
@@ -64,7 +68,7 @@
             // 
             this.comboBox_currentRegion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBox_currentRegion.FormattingEnabled = true;
-            this.comboBox_currentRegion.Location = new System.Drawing.Point(2, 21);
+            this.comboBox_currentRegion.Location = new System.Drawing.Point(13, 21);
             this.comboBox_currentRegion.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox_currentRegion.Name = "comboBox_currentRegion";
             this.comboBox_currentRegion.Size = new System.Drawing.Size(183, 21);
@@ -74,7 +78,7 @@
             // label_currentRegion
             // 
             this.label_currentRegion.AutoSize = true;
-            this.label_currentRegion.Location = new System.Drawing.Point(2, 6);
+            this.label_currentRegion.Location = new System.Drawing.Point(13, 6);
             this.label_currentRegion.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label_currentRegion.Name = "label_currentRegion";
             this.label_currentRegion.Size = new System.Drawing.Size(73, 13);
@@ -84,20 +88,20 @@
             // splitContainer1
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 53);
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
             this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.dataGridView_codexEntries);
+            this.splitContainer1.Panel1.Controls.Add(this.splitContainer2);
             // 
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.textBox_logMsgs);
-            this.splitContainer1.Size = new System.Drawing.Size(793, 520);
-            this.splitContainer1.SplitterDistance = 321;
+            this.splitContainer1.Size = new System.Drawing.Size(793, 573);
+            this.splitContainer1.SplitterDistance = 353;
             this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 4;
             // 
@@ -105,9 +109,9 @@
             // 
             this.dataGridView_codexEntries.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView_codexEntries.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dataGridView_codexEntries.Location = new System.Drawing.Point(0, 0);
+            this.dataGridView_codexEntries.Location = new System.Drawing.Point(0, 104);
             this.dataGridView_codexEntries.Name = "dataGridView_codexEntries";
-            this.dataGridView_codexEntries.Size = new System.Drawing.Size(793, 321);
+            this.dataGridView_codexEntries.Size = new System.Drawing.Size(369, 249);
             this.dataGridView_codexEntries.TabIndex = 0;
             // 
             // panel_topControls
@@ -121,41 +125,42 @@
             this.panel_topControls.Location = new System.Drawing.Point(0, 0);
             this.panel_topControls.Margin = new System.Windows.Forms.Padding(2);
             this.panel_topControls.Name = "panel_topControls";
-            this.panel_topControls.Size = new System.Drawing.Size(793, 53);
+            this.panel_topControls.Size = new System.Drawing.Size(369, 104);
             this.panel_topControls.TabIndex = 5;
-            // 
-            // comboBox_discoveryType
-            // 
-            this.comboBox_discoveryType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_discoveryType.FormattingEnabled = true;
-            this.comboBox_discoveryType.Location = new System.Drawing.Point(215, 21);
-            this.comboBox_discoveryType.Margin = new System.Windows.Forms.Padding(2);
-            this.comboBox_discoveryType.Name = "comboBox_discoveryType";
-            this.comboBox_discoveryType.Size = new System.Drawing.Size(183, 21);
-            this.comboBox_discoveryType.TabIndex = 4;
-            this.comboBox_discoveryType.SelectedIndexChanged += new System.EventHandler(this.comboBox_discoveryType_SelectedIndexChanged);
-            // 
-            // label_discoveryType
-            // 
-            this.label_discoveryType.AutoSize = true;
-            this.label_discoveryType.Location = new System.Drawing.Point(212, 6);
-            this.label_discoveryType.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label_discoveryType.Name = "label_discoveryType";
-            this.label_discoveryType.Size = new System.Drawing.Size(77, 13);
-            this.label_discoveryType.TabIndex = 3;
-            this.label_discoveryType.Text = "Discovery type";
             // 
             // groupBox_discoveryFilters
             // 
             this.groupBox_discoveryFilters.Controls.Add(this.radioButton_filterNotFound);
             this.groupBox_discoveryFilters.Controls.Add(this.radioButton_filterExisting);
             this.groupBox_discoveryFilters.Controls.Add(this.radioButton_filterAll);
-            this.groupBox_discoveryFilters.Location = new System.Drawing.Point(403, 6);
+            this.groupBox_discoveryFilters.Location = new System.Drawing.Point(246, 6);
             this.groupBox_discoveryFilters.Name = "groupBox_discoveryFilters";
-            this.groupBox_discoveryFilters.Size = new System.Drawing.Size(275, 39);
+            this.groupBox_discoveryFilters.Size = new System.Drawing.Size(98, 85);
             this.groupBox_discoveryFilters.TabIndex = 5;
             this.groupBox_discoveryFilters.TabStop = false;
             this.groupBox_discoveryFilters.Text = "Filter by";
+            // 
+            // radioButton_filterNotFound
+            // 
+            this.radioButton_filterNotFound.AutoSize = true;
+            this.radioButton_filterNotFound.Location = new System.Drawing.Point(6, 62);
+            this.radioButton_filterNotFound.Name = "radioButton_filterNotFound";
+            this.radioButton_filterNotFound.Size = new System.Drawing.Size(72, 17);
+            this.radioButton_filterNotFound.TabIndex = 2;
+            this.radioButton_filterNotFound.TabStop = true;
+            this.radioButton_filterNotFound.Text = "Not found";
+            this.radioButton_filterNotFound.UseVisualStyleBackColor = true;
+            // 
+            // radioButton_filterExisting
+            // 
+            this.radioButton_filterExisting.AutoSize = true;
+            this.radioButton_filterExisting.Location = new System.Drawing.Point(6, 39);
+            this.radioButton_filterExisting.Name = "radioButton_filterExisting";
+            this.radioButton_filterExisting.Size = new System.Drawing.Size(61, 17);
+            this.radioButton_filterExisting.TabIndex = 1;
+            this.radioButton_filterExisting.TabStop = true;
+            this.radioButton_filterExisting.Text = "Existing";
+            this.radioButton_filterExisting.UseVisualStyleBackColor = true;
             // 
             // radioButton_filterAll
             // 
@@ -168,34 +173,47 @@
             this.radioButton_filterAll.Text = "Show all";
             this.radioButton_filterAll.UseVisualStyleBackColor = true;
             // 
-            // radioButton_filterExisting
+            // comboBox_discoveryType
             // 
-            this.radioButton_filterExisting.AutoSize = true;
-            this.radioButton_filterExisting.Location = new System.Drawing.Point(77, 16);
-            this.radioButton_filterExisting.Name = "radioButton_filterExisting";
-            this.radioButton_filterExisting.Size = new System.Drawing.Size(61, 17);
-            this.radioButton_filterExisting.TabIndex = 1;
-            this.radioButton_filterExisting.TabStop = true;
-            this.radioButton_filterExisting.Text = "Existing";
-            this.radioButton_filterExisting.UseVisualStyleBackColor = true;
+            this.comboBox_discoveryType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox_discoveryType.FormattingEnabled = true;
+            this.comboBox_discoveryType.Location = new System.Drawing.Point(13, 70);
+            this.comboBox_discoveryType.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBox_discoveryType.Name = "comboBox_discoveryType";
+            this.comboBox_discoveryType.Size = new System.Drawing.Size(183, 21);
+            this.comboBox_discoveryType.TabIndex = 4;
+            this.comboBox_discoveryType.SelectedIndexChanged += new System.EventHandler(this.comboBox_discoveryType_SelectedIndexChanged);
             // 
-            // radioButton_filterNotFound
+            // label_discoveryType
             // 
-            this.radioButton_filterNotFound.AutoSize = true;
-            this.radioButton_filterNotFound.Location = new System.Drawing.Point(145, 16);
-            this.radioButton_filterNotFound.Name = "radioButton_filterNotFound";
-            this.radioButton_filterNotFound.Size = new System.Drawing.Size(72, 17);
-            this.radioButton_filterNotFound.TabIndex = 2;
-            this.radioButton_filterNotFound.TabStop = true;
-            this.radioButton_filterNotFound.Text = "Not found";
-            this.radioButton_filterNotFound.UseVisualStyleBackColor = true;
+            this.label_discoveryType.AutoSize = true;
+            this.label_discoveryType.Location = new System.Drawing.Point(10, 55);
+            this.label_discoveryType.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label_discoveryType.Name = "label_discoveryType";
+            this.label_discoveryType.Size = new System.Drawing.Size(77, 13);
+            this.label_discoveryType.TabIndex = 3;
+            this.label_discoveryType.Text = "Discovery type";
+            // 
+            // splitContainer2
+            // 
+            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Name = "splitContainer2";
+            // 
+            // splitContainer2.Panel1
+            // 
+            this.splitContainer2.Panel1.Controls.Add(this.dataGridView_codexEntries);
+            this.splitContainer2.Panel1.Controls.Add(this.panel_topControls);
+            this.splitContainer2.Size = new System.Drawing.Size(793, 353);
+            this.splitContainer2.SplitterDistance = 369;
+            this.splitContainer2.SplitterWidth = 5;
+            this.splitContainer2.TabIndex = 1;
             // 
             // PanelUserControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.splitContainer1);
-            this.Controls.Add(this.panel_topControls);
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "PanelUserControl";
             this.Size = new System.Drawing.Size(793, 573);
@@ -208,6 +226,9 @@
             this.panel_topControls.PerformLayout();
             this.groupBox_discoveryFilters.ResumeLayout(false);
             this.groupBox_discoveryFilters.PerformLayout();
+            this.splitContainer2.Panel1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
+            this.splitContainer2.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -226,5 +247,6 @@
         private System.Windows.Forms.RadioButton radioButton_filterNotFound;
         private System.Windows.Forms.RadioButton radioButton_filterExisting;
         private System.Windows.Forms.RadioButton radioButton_filterAll;
+        private System.Windows.Forms.SplitContainer splitContainer2;
     }
 }

--- a/EDCodex.Panel/PanelUserControl.Designer.cs
+++ b/EDCodex.Panel/PanelUserControl.Designer.cs
@@ -60,7 +60,7 @@
             this.textBox_logMsgs.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_logMsgs.Name = "textBox_logMsgs";
             this.textBox_logMsgs.ReadOnly = true;
-            this.textBox_logMsgs.Size = new System.Drawing.Size(793, 217);
+            this.textBox_logMsgs.Size = new System.Drawing.Size(793, 120);
             this.textBox_logMsgs.TabIndex = 0;
             this.textBox_logMsgs.Text = "";
             // 
@@ -101,7 +101,7 @@
             // 
             this.splitContainer1.Panel2.Controls.Add(this.textBox_logMsgs);
             this.splitContainer1.Size = new System.Drawing.Size(793, 573);
-            this.splitContainer1.SplitterDistance = 353;
+            this.splitContainer1.SplitterDistance = 450;
             this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 4;
             // 
@@ -111,7 +111,7 @@
             this.dataGridView_codexEntries.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataGridView_codexEntries.Location = new System.Drawing.Point(0, 104);
             this.dataGridView_codexEntries.Name = "dataGridView_codexEntries";
-            this.dataGridView_codexEntries.Size = new System.Drawing.Size(369, 249);
+            this.dataGridView_codexEntries.Size = new System.Drawing.Size(369, 346);
             this.dataGridView_codexEntries.TabIndex = 0;
             // 
             // panel_topControls
@@ -204,7 +204,7 @@
             // 
             this.splitContainer2.Panel1.Controls.Add(this.dataGridView_codexEntries);
             this.splitContainer2.Panel1.Controls.Add(this.panel_topControls);
-            this.splitContainer2.Size = new System.Drawing.Size(793, 353);
+            this.splitContainer2.Size = new System.Drawing.Size(793, 450);
             this.splitContainer2.SplitterDistance = 369;
             this.splitContainer2.SplitterWidth = 5;
             this.splitContainer2.TabIndex = 1;

--- a/EDCodex.Panel/PanelUserControl.Designer.cs
+++ b/EDCodex.Panel/PanelUserControl.Designer.cs
@@ -258,6 +258,7 @@
             this.listBox_prefixes.Name = "listBox_prefixes";
             this.listBox_prefixes.Size = new System.Drawing.Size(419, 394);
             this.listBox_prefixes.TabIndex = 3;
+            this.listBox_prefixes.SelectedIndexChanged += new System.EventHandler(this.listBox_prefixes_SelectedIndexChanged);
             // 
             // PanelUserControl
             // 

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -434,6 +434,24 @@ namespace EDCodex.Panel
             }
         }
 
+        private void listBox_prefixes_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (listBox_prefixes.SelectedItem is string selectedPrefix 
+                && !string.IsNullOrWhiteSpace(selectedPrefix))
+            {
+                try
+                {
+                    Clipboard.SetText(selectedPrefix);
+                    _logger.Debug($"Clipboard set to selected prefix: {selectedPrefix}");
+
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug($"Failed to copy prefix to clipboard: {ex.Message}");
+                }
+            }
+        }
+
         #endregion
 
         /// <summary>

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -423,6 +423,8 @@ namespace EDCodex.Panel
 
             // List used; BindingList not needed for static data.
             listBox_prefixes.DataSource = PrefixService.GetAll(userInputSectorName, massIndices);
+
+            listBox_prefixes.Focus(); // Focus the listbox.
         }
 
         private void textBox_sectorName_KeyDown(object sender, KeyEventArgs e)

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -442,7 +442,7 @@ namespace EDCodex.Panel
                 try
                 {
                     Clipboard.SetText(selectedPrefix);
-                    _logger.Debug($"Clipboard set to selected prefix: {selectedPrefix}");
+                    _logger.LogMessage($"Clipboard set to selected prefix: {selectedPrefix}");
 
                 }
                 catch (Exception ex)

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -21,7 +21,7 @@ namespace EDCodex.Panel
         private EDDCallBacks DLLCallBack;
         private readonly Logger _logger;
         private BindingList<CodexEntryView> _filteredEntries = new BindingList<CodexEntryView>();
-
+        private BindingList<string> _prefixes = new BindingList<string>();
         private FilterType _currentFilter = FilterType.All;
         private GalacticRegion _selectedRegion = GalacticRegion.TheVoid;
         private CodexEntryType _selectedDiscoveryType = CodexEntryType.Star; // Default to Star
@@ -62,6 +62,8 @@ namespace EDCodex.Panel
             InitializeRadioButtonFilters();
             PopulateGalacticRegionsCombobox();
             PopulateDiscoveryTypesCombobox();
+
+            listBox_prefixes.DataSource = _prefixes;
 
             _logger.LogMessage("Welcome to EDCodex custom panel.");
         }
@@ -400,6 +402,26 @@ namespace EDCodex.Panel
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
                 _logger.Debug($"Error in DataGridView_codexEntries_CellValueChanged:\r\n{ex.Message}");
+            }
+        }
+
+        private void textBox_sectorName_TextChanged(object sender, EventArgs e)
+        {
+            // Enable button only if textbox has text
+            button_getPrefixes.Enabled = !string.IsNullOrWhiteSpace(textBox_sectorName.Text);
+        }
+
+        private void button_getPrefixes_Click(object sender, EventArgs e)
+        {
+            _prefixes.Add(textBox_sectorName.Text.Trim());
+        }
+
+        private void textBox_sectorName_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                button_getPrefixes.PerformClick();
+                e.Handled = true;
             }
         }
 

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -1,6 +1,7 @@
 ﻿using EDCodex.Data;
 using EDCodex.Data.Enums;
 using EDCodex.Data.Models;
+using EDCodex.Panel.Enums;
 using EDCodex.Panel.Extentions;
 using EDCodex.Panel.Models;
 using System;
@@ -21,7 +22,6 @@ namespace EDCodex.Panel
         private EDDCallBacks DLLCallBack;
         private readonly Logger _logger;
         private BindingList<CodexEntryView> _filteredEntries = new BindingList<CodexEntryView>();
-        private BindingList<string> _prefixes = new BindingList<string>();
         private FilterType _currentFilter = FilterType.All;
         private GalacticRegion _selectedRegion = GalacticRegion.TheVoid;
         private CodexEntryType _selectedDiscoveryType = CodexEntryType.Star; // Default to Star
@@ -63,7 +63,7 @@ namespace EDCodex.Panel
             PopulateGalacticRegionsCombobox();
             PopulateDiscoveryTypesCombobox();
 
-            listBox_prefixes.DataSource = _prefixes;
+            listBox_prefixes.DataSource = new List<string>();
 
             _logger.LogMessage("Welcome to EDCodex custom panel.");
         }
@@ -413,7 +413,16 @@ namespace EDCodex.Panel
 
         private void button_getPrefixes_Click(object sender, EventArgs e)
         {
-            _prefixes.Add(textBox_sectorName.Text.Trim());
+            var userInputSectorName = textBox_sectorName.Text.Trim();
+            var massIndices = new List<MassIndex>()
+            {
+                // Hardcoded for now.
+                MassIndex.G,
+                MassIndex.H
+            };
+
+            // List used; BindingList not needed for static data.
+            listBox_prefixes.DataSource = PrefixService.GetAll(userInputSectorName, massIndices);
         }
 
         private void textBox_sectorName_KeyDown(object sender, KeyEventArgs e)

--- a/EDCodex.Panel/PrefixService.cs
+++ b/EDCodex.Panel/PrefixService.cs
@@ -1,0 +1,47 @@
+﻿using EDCodex.Panel.Enums;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EDCodex.Panel
+{
+    public static class PrefixService
+    {
+        /// <summary>
+        /// Returns a list of formatted prefixes for the given sector name and mass indices.
+        /// The mass indices are processed in reverse alphabetical order (from H to A).
+        /// </summary>
+        /// <param name="sectorName">The name of the sector to include in each prefix.</param>
+        /// <param name="massIndices">The list of mass indices to process.</param>
+        /// <returns>
+        /// A <see cref="List{T}"/> of prefixes, where each one is formatted as:
+        /// [&lt;Sector&gt; &lt;Cube&gt; &lt;MassIndex&gt;].
+        /// </returns>
+        public static List<string> GetAll(string sectorName, List<MassIndex> massIndices)
+        {
+            var prefixes = new List<string>();
+
+            if (massIndices == null || !massIndices.Any())
+            {
+                return prefixes;
+            }
+
+            var massIndicesDescending = massIndices.OrderByDescending(mi => mi);
+
+            foreach (var massIndex in massIndicesDescending)
+            {
+                var cubes = CubeService.GetForMassIndex(massIndex);
+                if (cubes == null || !cubes.Any())
+                {
+                    continue;
+                }
+
+                foreach (var cube in cubes)
+                {
+                    prefixes.Add($"{sectorName} {cube} {massIndex}");
+                }
+            }
+
+            return prefixes;
+        }
+    }
+}

--- a/EDCodex.Panel/PrefixService.cs
+++ b/EDCodex.Panel/PrefixService.cs
@@ -20,24 +20,22 @@ namespace EDCodex.Panel
         {
             var prefixes = new List<string>();
 
-            if (massIndices == null || !massIndices.Any())
+            if (massIndices != null && massIndices.Count > 0)
             {
-                return prefixes;
-            }
+                var massIndicesDescending = massIndices.OrderByDescending(mi => mi);
 
-            var massIndicesDescending = massIndices.OrderByDescending(mi => mi);
-
-            foreach (var massIndex in massIndicesDescending)
-            {
-                var cubes = CubeService.GetForMassIndex(massIndex);
-                if (cubes == null || !cubes.Any())
+                foreach (var massIndex in massIndicesDescending)
                 {
-                    continue;
-                }
+                    var cubes = CubeService.GetForMassIndex(massIndex);
+                    if (cubes == null || cubes.Count == 0)
+                    {
+                        continue;
+                    }
 
-                foreach (var cube in cubes)
-                {
-                    prefixes.Add($"{sectorName} {cube} {massIndex}");
+                    foreach (var cube in cubes)
+                    {
+                        prefixes.Add($"{sectorName} {cube} {massIndex}");
+                    }
                 }
             }
 

--- a/EDCodex.Panel/PrefixService.cs
+++ b/EDCodex.Panel/PrefixService.cs
@@ -20,14 +20,14 @@ namespace EDCodex.Panel
         {
             var prefixes = new List<string>();
 
-            if (massIndices != null && massIndices.Count > 0)
+            if (massIndices?.Count > 0)
             {
                 var massIndicesDescending = massIndices.OrderByDescending(mi => mi);
 
                 foreach (var massIndex in massIndicesDescending)
                 {
                     var cubes = CubeService.GetForMassIndex(massIndex);
-                    if (cubes == null || cubes.Count == 0)
+                    if (cubes?.Count == 0)
                     {
                         continue;
                     }


### PR DESCRIPTION
The panel now is able to give all possible prefixes for the entered sector name.
After pressing Enter or clicking the button the focus moves to the listbox for easy prefix selection with the arrow keys. 
Selected prefix is automatically copied to the clipboard.

Closes Keen13/EDCodex#23