### PR TITLE
Hotkeys and discovery status refactoring

### DIFF
--- a/EDCodex.Console/Load/BioFeaturesData.cs
+++ b/EDCodex.Console/Load/BioFeaturesData.cs
@@ -58,7 +58,7 @@ public class BioFeaturesData
             };
     }
 
-    // List only existing Terrestrials types for a region. Other will be marked as NotExists by default
+    // List only existing Terrestrials types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<BioCodexEntry> Data18 =>
         [

--- a/EDCodex.Console/Load/GasGiantPlanetsData.cs
+++ b/EDCodex.Console/Load/GasGiantPlanetsData.cs
@@ -58,7 +58,7 @@ public class GasGiantPlanetsData
             };
     }
 
-    // List only existing Gas Giants types for a region. Other will be marked as NotExists by default
+    // List only existing Gas Giants types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<GasGiantPlanetCodexEntry> Data18 =>
         [        

--- a/EDCodex.Console/Load/GeoFeaturesData.cs
+++ b/EDCodex.Console/Load/GeoFeaturesData.cs
@@ -58,7 +58,7 @@ public class GeoFeaturesData
             };
     }
 
-    // List only existing Terrestrials types for a region. Other will be marked as NotExists by default
+    // List only existing Terrestrials types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<GeoCodexEntry> Data18 =>
         new List<GeoCodexEntry>

--- a/EDCodex.Console/Load/GuardianObjectsData.cs
+++ b/EDCodex.Console/Load/GuardianObjectsData.cs
@@ -58,7 +58,7 @@ public class GuardianObjectsData
             };
     }
 
-    // List only existing Terrestrials types for a region. Other will be marked as NotExists by default
+    // List only existing Terrestrials types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<GuardianCodexEntry> Data18 =>
         new List<GuardianCodexEntry>

--- a/EDCodex.Console/Load/SpaceBioFeaturesData.cs
+++ b/EDCodex.Console/Load/SpaceBioFeaturesData.cs
@@ -58,7 +58,7 @@ public class SpaceBioFeaturesData
             };
     }
 
-    // List only existing Terrestrials types for a region. Other will be marked as NotExists by default
+    // List only existing Terrestrials types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<SpaceBioCodexEntry> Data18 =>
         new List<SpaceBioCodexEntry>

--- a/EDCodex.Console/Load/SpaceFeaturesData.cs
+++ b/EDCodex.Console/Load/SpaceFeaturesData.cs
@@ -58,7 +58,7 @@ public class SpaceFeaturesData
             };
     }
 
-    // List only existing Terrestrials types for a region. Other will be marked as NotExists by default
+    // List only existing Terrestrials types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<SpaceCodexEntry> Data18 =>
         new List<SpaceCodexEntry>

--- a/EDCodex.Console/Load/StarsData.cs
+++ b/EDCodex.Console/Load/StarsData.cs
@@ -58,7 +58,7 @@ public static class StarsData
             };
     }
 
-    // List only existing star types for a region. Other will be marked as NotExists by default
+    // List only existing star types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<StarCodexEntry> Data01 =>
         new List<StarCodexEntry>

--- a/EDCodex.Console/Load/TerrestrialPlanetsData.cs
+++ b/EDCodex.Console/Load/TerrestrialPlanetsData.cs
@@ -58,7 +58,7 @@ public class TerrestrialPlanetsData
             };
     }
 
-    // List only existing Terrestrials types for a region. Other will be marked as NotExists by default
+    // List only existing Terrestrials types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<TerrestrialPlanetCodexEntry> Data18 =>
         new List<TerrestrialPlanetCodexEntry>

--- a/EDCodex.Console/Load/ThargoidObjectsData.cs
+++ b/EDCodex.Console/Load/ThargoidObjectsData.cs
@@ -58,7 +58,7 @@ public class ThargoidObjectsData
             };
     }
 
-    // List only existing Terrestrials types for a region. Other will be marked as NotExists by default
+    // List only existing Terrestrials types for a region. Other will be marked as Absent by default
     // Use Data18 as template
     public static List<ThargiodCodexEntry> Data18 =>
         new List<ThargiodCodexEntry>

--- a/EDCodex.Console/Menu/UpdateCodexEntryMenu.cs
+++ b/EDCodex.Console/Menu/UpdateCodexEntryMenu.cs
@@ -17,7 +17,7 @@ public class UpdateCodexEntryMenu<TCodexEntryType> : MenuBase, IMenu
     protected override void InitializeOptions()
     {
         AddOption("1", "Mark as Found", MarkAsFoundCommand);
-        AddOption("2", "Mark as NotExists", MarkAsNotExistsCommand);
+        AddOption("2", "Mark as Absent", MarkAsAbsentCommand);
         AddOption("3", "Show Requirements", ShowRequirementsCommand);
     }
 
@@ -38,11 +38,11 @@ public class UpdateCodexEntryMenu<TCodexEntryType> : MenuBase, IMenu
         return false; // Automatically returns from this menu to the previous one
     }
     
-    private bool MarkAsNotExistsCommand()
+    private bool MarkAsAbsentCommand()
     {
-        _entryToUpdate.MarkAsNotExists(CurrentRegion);
+        _entryToUpdate.MarkAsAbsent(CurrentRegion);
         DbAccessor.SaveCodex();
-        Console.WriteLine($"{_entryToUpdate.Description} is NotExists now");
+        Console.WriteLine($"{_entryToUpdate.Description} is Absent now");
         Console.ReadLine();
         return false; // Automatically returns from this menu to the previous one
     }

--- a/EDCodex.Data/Enums/CodexEntryStatus.cs
+++ b/EDCodex.Data/Enums/CodexEntryStatus.cs
@@ -2,7 +2,7 @@
 
 public enum CodexEntryStatus
 {
-    NotExists = 1,
+    Absent = 1,
     
     NotFound = 2,
     

--- a/EDCodex.Data/Models/CodexEntry.cs
+++ b/EDCodex.Data/Models/CodexEntry.cs
@@ -42,7 +42,7 @@ public class CodexEntry<T> : ICodexEntry
         StatusByGalacticRegion[galacticRegion] = CodexEntryStatus.Found;
     }
 
-    public void MarkAsNotExists(GalacticRegion galacticRegion)
+    public void MarkAsAbsent(GalacticRegion galacticRegion)
     {
         StatusByGalacticRegion[galacticRegion] = CodexEntryStatus.Absent;
     }

--- a/EDCodex.Data/Models/CodexEntry.cs
+++ b/EDCodex.Data/Models/CodexEntry.cs
@@ -44,7 +44,7 @@ public class CodexEntry<T> : ICodexEntry
 
     public void MarkAsNotExists(GalacticRegion galacticRegion)
     {
-        StatusByGalacticRegion[galacticRegion] = CodexEntryStatus.NotExists;
+        StatusByGalacticRegion[galacticRegion] = CodexEntryStatus.Absent;
     }
 
     public void MarkAsExists(GalacticRegion galacticRegion)

--- a/EDCodex.Data/Models/GasGiantPlanetCodexEntry.cs
+++ b/EDCodex.Data/Models/GasGiantPlanetCodexEntry.cs
@@ -5,7 +5,7 @@ namespace EDCodex.Data.Models;
 public class GasGiantPlanetCodexEntry : CodexEntry<GasGiantPlanetType>
 {
     // Codex entries without additional requirements should be initialized as NotExists
-    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.NotExists;
+    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public GasGiantPlanetCodexEntry() : base(CodexEntryType.GasGiantPlanet)
     {

--- a/EDCodex.Data/Models/GasGiantPlanetCodexEntry.cs
+++ b/EDCodex.Data/Models/GasGiantPlanetCodexEntry.cs
@@ -4,7 +4,7 @@ namespace EDCodex.Data.Models;
 
 public class GasGiantPlanetCodexEntry : CodexEntry<GasGiantPlanetType>
 {
-    // Codex entries without additional requirements should be initialized as NotExists
+    // Codex entries without additional requirements should be initialized as Absent
     protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public GasGiantPlanetCodexEntry() : base(CodexEntryType.GasGiantPlanet)

--- a/EDCodex.Data/Models/GuardianCodexEntry.cs
+++ b/EDCodex.Data/Models/GuardianCodexEntry.cs
@@ -5,7 +5,7 @@ namespace EDCodex.Data.Models;
 public class GuardianCodexEntry : CodexEntry<GuardianObject>
 {
     // Codex entries without additional requirements should be initialized as NotExists
-    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.NotExists;
+    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public GuardianCodexEntry() : base(CodexEntryType.Guardian)
     {

--- a/EDCodex.Data/Models/GuardianCodexEntry.cs
+++ b/EDCodex.Data/Models/GuardianCodexEntry.cs
@@ -4,7 +4,7 @@ namespace EDCodex.Data.Models;
 
 public class GuardianCodexEntry : CodexEntry<GuardianObject>
 {
-    // Codex entries without additional requirements should be initialized as NotExists
+    // Codex entries without additional requirements should be initialized as Absent
     protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public GuardianCodexEntry() : base(CodexEntryType.Guardian)

--- a/EDCodex.Data/Models/StarCodexEntry.cs
+++ b/EDCodex.Data/Models/StarCodexEntry.cs
@@ -4,7 +4,7 @@ namespace EDCodex.Data.Models;
 
 public class StarCodexEntry : CodexEntry<StarClass>
 {
-    // Codex entries without additional requirements should be initialized as NotExists
+    // Codex entries without additional requirements should be initialized as Absent
     protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
     
     public StarCodexEntry() : base(CodexEntryType.Star)

--- a/EDCodex.Data/Models/StarCodexEntry.cs
+++ b/EDCodex.Data/Models/StarCodexEntry.cs
@@ -5,7 +5,7 @@ namespace EDCodex.Data.Models;
 public class StarCodexEntry : CodexEntry<StarClass>
 {
     // Codex entries without additional requirements should be initialized as NotExists
-    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.NotExists;
+    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
     
     public StarCodexEntry() : base(CodexEntryType.Star)
     {

--- a/EDCodex.Data/Models/TerrestrialPlanetCodexEntry.cs
+++ b/EDCodex.Data/Models/TerrestrialPlanetCodexEntry.cs
@@ -4,7 +4,7 @@ namespace EDCodex.Data.Models;
 
 public class TerrestrialPlanetCodexEntry : CodexEntry<TerrestrialPlanetType>
 {
-    // Codex entries without additional requirements should be initialized as NotExists
+    // Codex entries without additional requirements should be initialized as Absent
     protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public TerrestrialPlanetCodexEntry() : base(CodexEntryType.TerrestrialPlanet)

--- a/EDCodex.Data/Models/TerrestrialPlanetCodexEntry.cs
+++ b/EDCodex.Data/Models/TerrestrialPlanetCodexEntry.cs
@@ -5,7 +5,7 @@ namespace EDCodex.Data.Models;
 public class TerrestrialPlanetCodexEntry : CodexEntry<TerrestrialPlanetType>
 {
     // Codex entries without additional requirements should be initialized as NotExists
-    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.NotExists;
+    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public TerrestrialPlanetCodexEntry() : base(CodexEntryType.TerrestrialPlanet)
     {

--- a/EDCodex.Data/Models/ThargiodCodexEntry.cs
+++ b/EDCodex.Data/Models/ThargiodCodexEntry.cs
@@ -4,7 +4,7 @@ namespace EDCodex.Data.Models;
 
 public class ThargiodCodexEntry : CodexEntry<ThargoidObject>
 {
-    // Codex entries without additional requirements should be initialized as NotExists
+    // Codex entries without additional requirements should be initialized as Absent
     protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public ThargiodCodexEntry() : base(CodexEntryType.Thargiod)

--- a/EDCodex.Data/Models/ThargiodCodexEntry.cs
+++ b/EDCodex.Data/Models/ThargiodCodexEntry.cs
@@ -5,7 +5,7 @@ namespace EDCodex.Data.Models;
 public class ThargiodCodexEntry : CodexEntry<ThargoidObject>
 {
     // Codex entries without additional requirements should be initialized as NotExists
-    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.NotExists;
+    protected override CodexEntryStatus DefaultEntryStatus => CodexEntryStatus.Absent;
 
     public ThargiodCodexEntry() : base(CodexEntryType.Thargiod)
     {

--- a/EDCodex.Panel/PanelUserControl.Designer.cs
+++ b/EDCodex.Panel/PanelUserControl.Designer.cs
@@ -139,7 +139,6 @@
             this.dataGridView_codexEntries.RowHeadersWidth = 62;
             this.dataGridView_codexEntries.Size = new System.Drawing.Size(553, 531);
             this.dataGridView_codexEntries.TabIndex = 0;
-            this.dataGridView_codexEntries.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView_codexEntries_KeyDown);
             // 
             // panel_topControls
             // 
@@ -253,7 +252,7 @@
             this.listBox_prefixes.Location = new System.Drawing.Point(0, 227);
             this.listBox_prefixes.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.listBox_prefixes.Name = "listBox_prefixes";
-            this.listBox_prefixes.Size = new System.Drawing.Size(621, 464);
+            this.listBox_prefixes.Size = new System.Drawing.Size(617, 464);
             this.listBox_prefixes.TabIndex = 3;
             this.listBox_prefixes.SelectedIndexChanged += new System.EventHandler(this.listBox_prefixes_SelectedIndexChanged);
             // 

--- a/EDCodex.Panel/PanelUserControl.Designer.cs
+++ b/EDCodex.Panel/PanelUserControl.Designer.cs
@@ -139,6 +139,7 @@
             this.dataGridView_codexEntries.RowHeadersWidth = 62;
             this.dataGridView_codexEntries.Size = new System.Drawing.Size(553, 531);
             this.dataGridView_codexEntries.TabIndex = 0;
+            this.dataGridView_codexEntries.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView_codexEntries_KeyDown);
             // 
             // panel_topControls
             // 

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -428,22 +428,26 @@ namespace EDCodex.Panel
         {
             if (dataGridView_codexEntries.CurrentCell is null)
             {
+                _logger.Debug("KeyDown ignored: no current cell.");
                 return;
             }
 
             switch (e.KeyCode)
             {
                 case Keys.A:
+                    _logger.Debug("Hotkey A triggered.");
                     SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Absent);
                     e.Handled = true;
                     break;
 
                 case Keys.F:
+                    _logger.Debug("Hotkey F triggered.");
                     SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Found);
                     e.Handled = true;
                     break;
 
                 case Keys.N:
+                    _logger.Debug("Hotkey N triggered.");
                     SetSelectedEntryStatusFromHotkey(CodexEntryStatus.NotFound);
                     e.Handled = true;
                     break;
@@ -556,10 +560,23 @@ namespace EDCodex.Panel
         private void SetSelectedEntryStatusFromHotkey(CodexEntryStatus newStatus)
         {
             var entry = dataGridView_codexEntries.CurrentCell?.OwningRow?.DataBoundItem as CodexEntryView;
+            
+            if (entry is null)
+            {
+                _logger.Debug("Hotkey ignored: no selected entry.");
+                return;
+            }
+
+            _logger.Debug($"Attempting status change to {newStatus} for {entry.Description}");
 
             if (TryUpdateEntryStatus(entry, newStatus))
             {
+                _logger.Debug("Status updated successfully. Refreshing grid.");
                 RefreshGridState();
+            }
+            else
+            {
+                _logger.Debug("Status update skipped (no change).");
             }
         }
 
@@ -572,6 +589,7 @@ namespace EDCodex.Panel
 
             if (grid.CurrentCell is null)
             {
+                _logger.Debug("RefreshGridState aborted: no current cell.");
                 return;
             }
 
@@ -603,8 +621,15 @@ namespace EDCodex.Panel
         /// </summary>
         private bool TryUpdateEntryStatus(CodexEntryView entry, CodexEntryStatus newStatus)
         {
-            if (entry is null || entry.Status == newStatus)
+            if (entry is null)
             {
+                _logger.Debug("TryUpdateEntryStatus: entry is null.");
+                return false;
+            }
+
+            if (entry.Status == newStatus)
+            {
+                _logger.Debug($"TryUpdateEntryStatus: no change for {entry.Description}");
                 return false;
             }
 

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -556,7 +556,42 @@ namespace EDCodex.Panel
 
         private void dataGridView_codexEntries_KeyDown(object sender, KeyEventArgs e)
         {
+            if (dataGridView_codexEntries.CurrentCell is null)
+            {
+                return;
+            }
 
-        }
+            switch (e.KeyCode)
+            {
+                case Keys.A:
+                    _logger.Debug("Hotkey A triggered.");
+
+                    if (dataGridView_codexEntries.CurrentCell?.RowIndex is int idx && idx >= 0)
+                    {
+                        if (dataGridView_codexEntries.Rows[idx].DataBoundItem is CodexEntryView entry)
+                        {
+                            if (entry.Status != CodexEntryStatus.Absent)
+                            {
+                                var oldValue = entry.Status;
+                                entry.Status = CodexEntryStatus.Absent;
+
+                                dataGridView_codexEntries.InvalidateRow(idx);
+
+                                _logger.Debug($"{entry.Description}: {oldValue} —> {entry.Status}");
+
+                                DbAccessor.SaveCodex();
+                                _logger.Debug("Codex saved.");
+                                BeginInvoke(new MethodInvoker(() => ApplyCombinedFilter()));
+                            }
+                        }
+                    }
+
+                    e.Handled = true;
+                    break;
+
+                default:
+                    break;
+            }            
+        }        
     }
 }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -566,16 +566,16 @@ namespace EDCodex.Panel
                 case Keys.A:
                     _logger.Debug("Hotkey A triggered.");
 
-                    HandleHotkey(e, CodexEntryStatus.Absent);
+                    SetSelectedEntryStatusFromHotkey(e, CodexEntryStatus.Absent);
                     break;
                 case Keys.F:
                     _logger.Debug("Hotkey F triggered.");
-                    HandleHotkey(e, CodexEntryStatus.Found);
+                    SetSelectedEntryStatusFromHotkey(e, CodexEntryStatus.Found);
                     break;
 
                 case Keys.N:
                     _logger.Debug("Hotkey N triggered.");
-                    HandleHotkey(e, CodexEntryStatus.NotFound);
+                    SetSelectedEntryStatusFromHotkey(e, CodexEntryStatus.NotFound);
                     break;
 
                 default:
@@ -583,7 +583,7 @@ namespace EDCodex.Panel
             }            
         }
 
-        private void HandleHotkey(KeyEventArgs e, CodexEntryStatus newStatus)
+        private void SetSelectedEntryStatusFromHotkey(KeyEventArgs e, CodexEntryStatus newStatus)
         {
             var grid = dataGridView_codexEntries;
             var currentCell = grid.CurrentCell;

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -566,66 +566,81 @@ namespace EDCodex.Panel
                 case Keys.A:
                     _logger.Debug("Hotkey A triggered.");
 
-                    if (dataGridView_codexEntries.CurrentCell?.RowIndex is int idx && idx >= 0)
-                    {
-                        if (dataGridView_codexEntries.Rows[idx].DataBoundItem is CodexEntryView entry)
-                        {
-                            if (entry.Status != CodexEntryStatus.Absent)
-                            {
-                                var oldIndex = dataGridView_codexEntries.CurrentCell.RowIndex;
-                                var firstDisplayed = dataGridView_codexEntries.FirstDisplayedScrollingRowIndex;
-
-                                var oldValue = entry.Status;
-                                entry.Status = CodexEntryStatus.Absent;
-
-                                dataGridView_codexEntries.InvalidateRow(idx);
-
-                                _logger.Debug($"{entry.Description}: {oldValue} —> {entry.Status}");
-
-                                DbAccessor.SaveCodex();
-                                _logger.Debug("Codex saved.");
-                                BeginInvoke(new MethodInvoker(() =>
-                                {
-                                    ApplyCombinedFilter();
-
-                                    if (dataGridView_codexEntries.Rows.Count == 0)
-                                    {
-                                        return;
-                                    }
-
-                                    var newIndex = oldIndex;
-
-                                    if (newIndex >= dataGridView_codexEntries.Rows.Count)
-                                    {
-                                        newIndex = dataGridView_codexEntries.Rows.Count - 1;
-                                    }
-
-                                    if (newIndex < 0)
-                                    {
-                                        newIndex = 0;
-                                    }
-
-                                    dataGridView_codexEntries.CurrentCell =
-                                        dataGridView_codexEntries.Rows[newIndex].Cells[0];
-
-                                    if (firstDisplayed >= 0 &&
-                                        firstDisplayed < dataGridView_codexEntries.Rows.Count)
-                                    {
-                                        dataGridView_codexEntries.FirstDisplayedScrollingRowIndex = firstDisplayed;
-                                    }
-                                }));
-                            }
-                        }
-                    }
-
-                    e.Handled = true;
+                    HandleHotkey(e, CodexEntryStatus.Absent);
                     break;
 
                 default:
                     break;
             }            
-        }     
-        
+        }
 
+        private void HandleHotkey(KeyEventArgs e, CodexEntryStatus newStatus)
+        {
+            var grid = dataGridView_codexEntries;
+            var currentCell = grid.CurrentCell;
+
+            if (currentCell == null || currentCell.RowIndex < 0)
+            {
+                return;
+            }
+
+            var idx = currentCell.RowIndex;
+
+            var entry = grid.Rows[idx].DataBoundItem as CodexEntryView;
+            if (entry == null)
+            {
+                return;
+            }
+
+            if (entry.Status == newStatus)
+            {
+                return;
+            }
+
+            // Saving the position of the row before the filter is applied.
+            var oldIndex = idx;
+
+            var firstDisplayed = grid.FirstDisplayedScrollingRowIndex;
+            var oldValue = entry.Status;
+
+            entry.Status = newStatus;
+
+            _logger.LogMessage($"{entry.Description}: {oldValue} —> {entry.Status}");
+
+            DbAccessor.SaveCodex();
+            BeginInvoke(new MethodInvoker(() =>
+            {
+                ApplyCombinedFilter();
+
+                if (grid.Rows.Count == 0)
+                {
+                    return;
+                }
+
+                var newIndex = oldIndex;
+
+                if (newIndex >= grid.Rows.Count)
+                {
+                    newIndex = grid.Rows.Count - 1;
+                }
+
+                if (newIndex < 0)
+                {
+                    newIndex = 0;
+                }
+
+                if (firstDisplayed >= 0 &&
+                    firstDisplayed < grid.Rows.Count)
+                {
+                    grid.FirstDisplayedScrollingRowIndex = firstDisplayed;
+                }
+
+                grid.CurrentCell =
+                    grid.Rows[newIndex].Cells[0];
+                
+            }));
+
+            e.Handled = true;
+        }
     }
 }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -424,6 +424,32 @@ namespace EDCodex.Panel
             }
         }
 
+        private void dataGridView_codexEntries_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (dataGridView_codexEntries.CurrentCell is null)
+            {
+                return;
+            }
+
+            switch (e.KeyCode)
+            {
+                case Keys.A:
+                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Absent);
+                    e.Handled = true;
+                    break;
+
+                case Keys.F:
+                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Found);
+                    e.Handled = true;
+                    break;
+
+                case Keys.N:
+                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.NotFound);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
         #endregion
 
         /// <summary>
@@ -590,39 +616,6 @@ namespace EDCodex.Panel
             DbAccessor.SaveCodex();
 
             return true;
-        }
-
-        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
-        {
-            var grid = dataGridView_codexEntries;
-
-            if (grid.CurrentCell is null)
-            {
-                return base.ProcessCmdKey(ref msg, keyData);
-            }
-
-            // Hotkeys by key only (ignores modifiers)
-            switch (keyData & Keys.KeyCode)
-            {
-                case Keys.A:
-                    _logger.Debug("Hotkey A triggered.");
-                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Absent);
-
-                    return true;
-                case Keys.F:
-                    _logger.Debug("Hotkey F triggered.");
-                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Found);
-
-                    return true;
-
-                case Keys.N:
-                    _logger.Debug("Hotkey N triggered.");
-                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.NotFound);
-
-                    return true;
-            }
-
-            return base.ProcessCmdKey(ref msg, keyData);
-        }
+        }        
     }
 }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -572,6 +572,9 @@ namespace EDCodex.Panel
                         {
                             if (entry.Status != CodexEntryStatus.Absent)
                             {
+                                var oldIndex = dataGridView_codexEntries.CurrentCell.RowIndex;
+                                var firstDisplayed = dataGridView_codexEntries.FirstDisplayedScrollingRowIndex;
+
                                 var oldValue = entry.Status;
                                 entry.Status = CodexEntryStatus.Absent;
 
@@ -581,7 +584,36 @@ namespace EDCodex.Panel
 
                                 DbAccessor.SaveCodex();
                                 _logger.Debug("Codex saved.");
-                                BeginInvoke(new MethodInvoker(() => ApplyCombinedFilter()));
+                                BeginInvoke(new MethodInvoker(() =>
+                                {
+                                    ApplyCombinedFilter();
+
+                                    if (dataGridView_codexEntries.Rows.Count == 0)
+                                    {
+                                        return;
+                                    }
+
+                                    var newIndex = oldIndex;
+
+                                    if (newIndex >= dataGridView_codexEntries.Rows.Count)
+                                    {
+                                        newIndex = dataGridView_codexEntries.Rows.Count - 1;
+                                    }
+
+                                    if (newIndex < 0)
+                                    {
+                                        newIndex = 0;
+                                    }
+
+                                    dataGridView_codexEntries.CurrentCell =
+                                        dataGridView_codexEntries.Rows[newIndex].Cells[0];
+
+                                    if (firstDisplayed >= 0 &&
+                                        firstDisplayed < dataGridView_codexEntries.Rows.Count)
+                                    {
+                                        dataGridView_codexEntries.FirstDisplayedScrollingRowIndex = firstDisplayed;
+                                    }
+                                }));
                             }
                         }
                     }
@@ -592,6 +624,8 @@ namespace EDCodex.Panel
                 default:
                     break;
             }            
-        }        
+        }     
+        
+
     }
 }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -554,49 +554,21 @@ namespace EDCodex.Panel
             }
         }
 
-        private void dataGridView_codexEntries_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (dataGridView_codexEntries.CurrentCell is null)
-            {
-                return;
-            }
-
-            switch (e.KeyCode)
-            {
-                case Keys.A:
-                    _logger.Debug("Hotkey A triggered.");
-
-                    SetSelectedEntryStatusFromHotkey(e, CodexEntryStatus.Absent);
-                    break;
-                case Keys.F:
-                    _logger.Debug("Hotkey F triggered.");
-                    SetSelectedEntryStatusFromHotkey(e, CodexEntryStatus.Found);
-                    break;
-
-                case Keys.N:
-                    _logger.Debug("Hotkey N triggered.");
-                    SetSelectedEntryStatusFromHotkey(e, CodexEntryStatus.NotFound);
-                    break;
-
-                default:
-                    break;
-            }            
-        }
-
-        private void SetSelectedEntryStatusFromHotkey(KeyEventArgs e, CodexEntryStatus newStatus)
+        private void SetSelectedEntryStatusFromHotkey(CodexEntryStatus newStatus)
         {
             var grid = dataGridView_codexEntries;
             var currentCell = grid.CurrentCell;
 
-            if (currentCell == null || currentCell.RowIndex < 0)
+            if (currentCell is null)
             {
                 return;
             }
 
             var idx = currentCell.RowIndex;
 
-            var entry = grid.Rows[idx].DataBoundItem as CodexEntryView;
-            if (entry == null)
+            //var entry = grid.Rows[idx].DataBoundItem as CodexEntryView;
+            var entry = currentCell.OwningRow?.DataBoundItem as CodexEntryView;
+            if (entry is null)
             {
                 return;
             }
@@ -648,8 +620,37 @@ namespace EDCodex.Panel
                     grid.Rows[newIndex].Cells[0];
                 
             }));
+        }
 
-            e.Handled = true;
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            var grid = dataGridView_codexEntries;
+
+            if (grid.CurrentCell is null)
+            {
+                return base.ProcessCmdKey(ref msg, keyData);
+            }
+
+            // Hotkeys by key only (ignores modifiers)
+            switch (keyData & Keys.KeyCode)
+            {
+                case Keys.A:
+                    _logger.Debug("Hotkey A triggered.");
+
+                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Absent);
+                    return true;
+                case Keys.F:
+                    _logger.Debug("Hotkey F triggered.");
+                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Found);
+                    return true;
+
+                case Keys.N:
+                    _logger.Debug("Hotkey N triggered.");
+                    SetSelectedEntryStatusFromHotkey(CodexEntryStatus.NotFound);
+                    return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
         }
     }
 }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -553,5 +553,10 @@ namespace EDCodex.Panel
                     return false; // Should not reach here. 
             }
         }
+
+        private void dataGridView_codexEntries_KeyDown(object sender, KeyEventArgs e)
+        {
+
+        }
     }
 }

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -568,6 +568,15 @@ namespace EDCodex.Panel
 
                     HandleHotkey(e, CodexEntryStatus.Absent);
                     break;
+                case Keys.F:
+                    _logger.Debug("Hotkey F triggered.");
+                    HandleHotkey(e, CodexEntryStatus.Found);
+                    break;
+
+                case Keys.N:
+                    _logger.Debug("Hotkey N triggered.");
+                    HandleHotkey(e, CodexEntryStatus.NotFound);
+                    break;
 
                 default:
                     break;

--- a/EDCodex.Panel/PanelUserControl.cs
+++ b/EDCodex.Panel/PanelUserControl.cs
@@ -360,48 +360,18 @@ namespace EDCodex.Panel
 
         private void DataGridView_codexEntries_CellValueChanged(object sender, DataGridViewCellEventArgs e)
         {
-            try
+            if (e.RowIndex < 0 || e.ColumnIndex < 0)
             {
-                _logger.Debug($"CellValueChanged triggered: RowIndex={e.RowIndex}, ColumnIndex={e.ColumnIndex}");
-
-                if (e.RowIndex < 0 || e.ColumnIndex < 0)
-                {
-                    _logger.Debug("Invalid row or column index in DataGridView.");
-                    return;
-                }
-
-                var row = dataGridView_codexEntries.Rows[e.RowIndex];
-                if (row.DataBoundItem is CodexEntryView entry)
-                {
-                    _logger.Debug($"Editing entry: '{entry}'");
-
-                    // Commit edit explicitly before saving
-                    dataGridView_codexEntries.CommitEdit(DataGridViewDataErrorContexts.Commit);
-                    dataGridView_codexEntries.EndEdit();
-
-                    DbAccessor.SaveCodex();
-                    _logger.Debug("Codex saved.");
-
-                    // Delay ApplyCombinedFilter to avoid race with internal updates
-                    BeginInvoke(new MethodInvoker(() =>
-                    {
-                        _logger.Debug("Reapplying combined filter after value change.");
-                        ApplyCombinedFilter();
-                    }));
-                }
-                else
-                {
-                    _logger.Debug("Row DataBoundItem is not a CodexEntryView — unexpected binding.");
-                }
+                return;
             }
-            catch (Exception ex)
+            
+            dataGridView_codexEntries.EndEdit();
+
+            if (dataGridView_codexEntries.Rows[e.RowIndex].DataBoundItem is CodexEntryView entry)
             {
-                MessageBox.Show(
-                    $"An error occurred while updating the codex entry. Please try again.\n{ex.Message}",
-                    "Error",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
-                _logger.Debug($"Error in DataGridView_codexEntries_CellValueChanged:\r\n{ex.Message}");
+                // Since the UI is already updated via Binding, just save and refresh filters.
+                DbAccessor.SaveCodex();
+                RefreshGridState();
             }
         }
 
@@ -554,41 +524,34 @@ namespace EDCodex.Panel
             }
         }
 
+        /// <summary>
+        /// Updates the selected codex entry status using keyboard shortcuts.
+        /// </summary>
         private void SetSelectedEntryStatusFromHotkey(CodexEntryStatus newStatus)
         {
+            var entry = dataGridView_codexEntries.CurrentCell?.OwningRow?.DataBoundItem as CodexEntryView;
+
+            if (TryUpdateEntryStatus(entry, newStatus))
+            {
+                RefreshGridState();
+            }
+        }
+
+        /// <summary>
+        /// Reapplies filters and restores grid selection and scroll position.
+        /// </summary>
+        private void RefreshGridState()
+        {
             var grid = dataGridView_codexEntries;
-            var currentCell = grid.CurrentCell;
 
-            if (currentCell is null)
+            if (grid.CurrentCell is null)
             {
                 return;
             }
 
-            var idx = currentCell.RowIndex;
-
-            //var entry = grid.Rows[idx].DataBoundItem as CodexEntryView;
-            var entry = currentCell.OwningRow?.DataBoundItem as CodexEntryView;
-            if (entry is null)
-            {
-                return;
-            }
-
-            if (entry.Status == newStatus)
-            {
-                return;
-            }
-
-            // Saving the position of the row before the filter is applied.
-            var oldIndex = idx;
-
+            var oldRowIndex = grid.CurrentCell.RowIndex;
             var firstDisplayed = grid.FirstDisplayedScrollingRowIndex;
-            var oldValue = entry.Status;
 
-            entry.Status = newStatus;
-
-            _logger.LogMessage($"{entry.Description}: {oldValue} —> {entry.Status}");
-
-            DbAccessor.SaveCodex();
             BeginInvoke(new MethodInvoker(() =>
             {
                 ApplyCombinedFilter();
@@ -598,28 +561,35 @@ namespace EDCodex.Panel
                     return;
                 }
 
-                var newIndex = oldIndex;
+                var newIndex = Math.Max(0, Math.Min(oldRowIndex, grid.Rows.Count - 1));
 
-                if (newIndex >= grid.Rows.Count)
-                {
-                    newIndex = grid.Rows.Count - 1;
-                }
-
-                if (newIndex < 0)
-                {
-                    newIndex = 0;
-                }
-
-                if (firstDisplayed >= 0 &&
-                    firstDisplayed < grid.Rows.Count)
+                if (firstDisplayed >= 0 && firstDisplayed < grid.Rows.Count)
                 {
                     grid.FirstDisplayedScrollingRowIndex = firstDisplayed;
                 }
 
-                grid.CurrentCell =
-                    grid.Rows[newIndex].Cells[0];
-                
+                grid.CurrentCell = grid.Rows[newIndex].Cells[0];
             }));
+        }
+
+        /// <summary>
+        /// Attempts to update a codex entry status and persist changes.
+        /// </summary>
+        private bool TryUpdateEntryStatus(CodexEntryView entry, CodexEntryStatus newStatus)
+        {
+            if (entry is null || entry.Status == newStatus)
+            {
+                return false;
+            }
+
+            var oldStatus = entry.Status;
+            entry.Status = newStatus;
+
+            _logger.LogMessage($"{entry.Description}: {oldStatus} —> {entry.Status}");
+
+            DbAccessor.SaveCodex();
+
+            return true;
         }
 
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
@@ -636,17 +606,19 @@ namespace EDCodex.Panel
             {
                 case Keys.A:
                     _logger.Debug("Hotkey A triggered.");
-
                     SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Absent);
+
                     return true;
                 case Keys.F:
                     _logger.Debug("Hotkey F triggered.");
                     SetSelectedEntryStatusFromHotkey(CodexEntryStatus.Found);
+
                     return true;
 
                 case Keys.N:
                     _logger.Debug("Hotkey N triggered.");
                     SetSelectedEntryStatusFromHotkey(CodexEntryStatus.NotFound);
+
                     return true;
             }
 


### PR DESCRIPTION
1. Refactored NotExists status into Absent.

2. Implemented hotkeys support when the data grid is in focus:
- 'F' for 'Found'
- 'N' for 'NotFound'
- 'A' for 'Absent'